### PR TITLE
Fixed bots being unable to learn skills from trainer

### DIFF
--- a/src/game/playerbot/PlayerbotAI.cpp
+++ b/src/game/playerbot/PlayerbotAI.cpp
@@ -7132,7 +7132,11 @@ void PlayerbotAI::_HandleCommandSkill(std::string &text, Player &fromPlayer)
                 if (!trainer_spell)
                     trainer_spell = tSpells->Find(spellId);
  
-                if (!trainer_spell || !trainer_spell->learnedSpell)
+                if (!trainer_spell)
+                    continue;
+
+                TrainerSpellState state = m_bot->GetTrainerSpellState(trainer_spell, trainer_spell->reqLevel);
+                if (state != TRAINER_SPELL_GREEN)
                     continue;
  
                 // apply reputation discount


### PR DESCRIPTION
I was unable to make a bot learn a new spell from the trainer at level 3.

To replicate the bug is easy, create new characters, level enough to learn a new spell from the starting trainer.
Using command "skill learn", the spell would show up, but upon using "skill learn [Link]" it didn't learn.